### PR TITLE
Reference the ToC instead of the plain Items node explanation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -48,7 +48,7 @@
   * [Movie \(XML\)](_gauntlet/movie.md)
 * [XML Documentation](_xmldocs/README.md)
   * [Atmosphere \(XML\)](_xmldocs/atmosphere.md)
-  * [Items \(XML\)](_xmldocs/Items/README.md)
+  * [Items \(XML\)](_xmldocs/items.md)
   * [Scene \(xScene\)](_xmldocs/scene.md)
   * [SubModule \(XML\)](_xmldocs/submodule.md)
 


### PR DESCRIPTION
The Items readme.md contains little information. Consider changing in to the items.md where a ToC is situated

The links in the items directory seems to be linking to the github repo instead of a gitbook page. Is it required to prefix `_xmldocs` to the links?