### PR TITLE
Fix load order in C# demo so new campaign can be launched

### DIFF
--- a/_tutorials/basic-csharp-mod.md
+++ b/_tutorials/basic-csharp-mod.md
@@ -67,7 +67,7 @@ Before setting up a project, it is important to know that **this is not required
 2. Select the `Start external program` option and then browse for `Bannerlord.exe` located in the `bin\Win64_Shipping_Client` directory in your game files \(not your module directory\).
 3. Set your working directory to the `bin\Win64_Shipping_Client` directory in your game files \(not your module directory\).
 4. Add the following command line arguments \(be sure to replace ExampleMod with the name of your module\):
-   * `/singleplayer _MODULES_*Native*SandBox*SandBoxCore*StoryMode*CustomBattle*ExampleMod*_MODULES_`
+   * `/singleplayer _MODULES_*Native*SandBoxCore*CustomBattle*SandBox*StoryMode*ExampleMod*_MODULES_`
 
 ## Programming
 


### PR DESCRIPTION
Just a simple re-order of the order of loaded modules. With this it should be possible to start a new campaign.