### PR TITLE
Stray tag in basic mod causing launcher crash fix

### DIFF
--- a/_tutorials/basic-csharp-mod.md
+++ b/_tutorials/basic-csharp-mod.md
@@ -40,7 +40,6 @@ The following guide will walk you through step-by-step on how to create a basic 
                 </Tags>
             </SubModule>
         </SubModules>
-        <Xmls/>
     </Module>
    ```
 


### PR DESCRIPTION
A stray enclosing XML tag causes the launcher to crash upon launch.