### PR TITLE
explain where Utilities.GetModulesNames() comes from

### DIFF
--- a/_csharp-api/library/moduleinfo.md
+++ b/_csharp-api/library/moduleinfo.md
@@ -2,6 +2,7 @@
 
 The ModuleInfo class contains information about each module.
 
+
 You can get a list of all **loaded** mods with detailed information about them (their ModuleInfo) by doing something like this:
 
 ```csharp
@@ -13,5 +14,6 @@ foreach(var moduleName in Utilities.GetModulesNames())
     loadedMods.Add(moduleInfo);
 }
 ```
+The Utilities class is part of the Talewords.Engine namespace, and the GetModulesNames() function returns a list of all the names of loaded modules.
 
 This could be used to determine whether a module has been loaded or not, which is useful for mods that have optional dependencies.


### PR DESCRIPTION
make it easier for the reader to understand that Uitilities.GetModulesNames() is the key part in the example.