### PR TITLE
Update basic-csharp-mod.md

### DIFF
--- a/_tutorials/basic-csharp-mod.md
+++ b/_tutorials/basic-csharp-mod.md
@@ -95,7 +95,7 @@ Before setting up a project, it is important to know that **this is not required
         new TextObject("Message", null),
         9990,
         () => { InformationManager.DisplayMessage(new InformationMessage("Hello World!")); },
-        false));
+        () => false));
    ```
 
 6. Compile your project and confirm that it was outputted to `Modules\ExampleMod\bin\Win64_Shipping_Client`.


### PR DESCRIPTION
As of 1.5.8, the AddInitialStateOption requires an arrow function (System.Func bool) instead of bool.