### PR TITLE
Restructure section on saving

### DIFF
--- a/docs/_csharp-api/savesystem/README.md
+++ b/docs/_csharp-api/savesystem/README.md
@@ -3,93 +3,136 @@
 ### Warning!  
 As of e1.0.10/e1.1.0 when defining custom data that inherits the game's basic types, be extra careful.  
 If the data will be saved to the game's internal storage, upon removing your mod the save won't be able to load because of your missing custom data.  
-This will be the case when definining custom ``LogEntry`` types and passing them to the game (``LogEntry.AddLogEntry(customLog);``.  
+This will be the case when definining custom ``LogEntry`` types and passing them to the game (``LogEntry.AddLogEntry(customLog);``).  
 As a workaround, you should either include a feature to fully remove your custom data from the game or provide a mod for it.
 
+## Basic saving
+
+The core of saving is ``CampaignBehaviorBase``'s ``SyncData`` function.  This will be called on any registered campaign behavior on both saving and loading.
+
+The method is provided a ``DataStore`` object with a ``SyncData`` method, which takes a [`ref` variable](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/ref). On save, data from the ref is read and stored in the savefile, on load, the ref will be populated with the data from the save file.
+
+```csharp
+public class CustomBehavior : CampaignBehaviorBase
+{
+    // The data in this field will persist across saving
+    public string Data;
+
+    public override void SyncData(IDataStore dataStore)
+    {
+        // First argument is an identifier, only needs to be unique to this behavior
+        dataStore.SyncData("Data", ref Data);
+    }
+
+    public override void RegisterEvents() { }
+}
+```
 
 ## SaveableTypeDefiner
-For defining custom classes and structs, implement your own ``TaleWorlds.SaveSystem.SaveableTypeDefiner``.  
+
+To save custom classes, structs, or built-in data structures (such as ``Array``, ``List``, ``Dictionary``, or ``Queue``), implement your own ``TaleWorlds.SaveSystem.SaveableTypeDefiner``, alongside the ``SyncData`` function.
 You don't need to register it somewhere, the game will find it itself via reflection.
+
+### Saving custom classes with SaveableTypeDefiner
+
+To make a custom class/struct saveable, register it inside ``DefineClassType`` in your ``SaveableTypeDefiner``.
+To mark data in your custom class/struct as saveable, use ``TaleWorlds.SaveSystem.SaveableFieldAttribute`` and ``TaleWorlds.SaveSystem.SaveablePropertyAttribute``.
+It seems that there is no real difference between ``SaveableField`` and ``SaveableProperty``, but if you used one of them, stick to the type. They are not interchangeable and the data won't be loaded if types awe switched.
+See the complete example below for examples of proper handling of ``SaveableField`` and ``SaveableProperty`` ids.
+
+### Saving data structures with SaveableTypeDefiner
+
+To save built-in data structures, register them in ``DefineContainerDefinitions``.  For example, if you want to save a list of ``ExampleStruct`` you would register:
 ```csharp
-    public class CustomSaveDefiner : SaveableTypeDefiner
-    {
-        // use a big number and ensure that no other mod is using a close range
-        public CustomSaveDefiner() : base(2 _333_000) { }
-
-        protected override void DefineClassTypes()
-        {
-            // The Id's here are local and will be related to the Id passed to the constructor
-            AddClassDefinition(typeof(CustomMapNotification), 1);
-            AddStructDefinition(typeof(ExampleStruct), 2);
-            AddClassDefinition(typeof(ExampleNested), 3);
-            AddStructDefinition(typeof(NestedStruct), 4);
-        }
-
-        protected override void DefineContainerDefinitions()
-        {
-            ConstructContainerDefinition(typeof(List<ExampleStruct>));
-        }
-    }
+protected override void DefineContainerDefinitions() {
+    ConstructContainerDefinition(typeof(List<ExampleStruct>));
+}
 ```
-  
-## SaveableField and SaveableProperty
-To mark data in your custom class/struct as savable, use ``TaleWorlds.SaveSystem.SaveableFieldAttribute`` and ``TaleWorlds.SaveSystem.SaveablePropertyAttribute``.  
-It seems that there is noreal difference between ``SaveableField`` and ``SaveableProperty``, but if you used one of them, stick to the type. They are not interchangeable and the data won't be loaded if types awe swicthed.  
+For nested structures, you'll need to register both the outer and inner structures.  For a ``Dictionary`` of ``List``s of ``ExampleStruct``, you would register:
+```csharp
+protected override void DefineContainerDefinitions() {
+    ConstructContainerDefinition(typeof(List<ExampleStruct>));
+    ConstructContainerDefinition(typeof(Dictionary<List<ExampleStruct>>));
+}
+```
+
+### Complete example with SaveableTypeDefiner
 
 ```csharp
-    public struct ExampleStruct
+public class CustomBehavior : CampaignBehaviorBase
+{
+    public ExampleStruct StructData;
+    public List<CustomMapNotification> MapNotificationList;
+    public Dictionary<string, List<NestedStruct>> NestedData;
+
+    public override void SyncData(IDataStore dataStore)
     {
-        // Local ID's start from one if the class/struct does not inherit from any
-        // game's types with saveable data
-        [SaveableField(1)]
-        public PartyBase Attacker;
+        dataStore.SyncData("StructData", ref StructData);
+        dataStore.SyncData("MapNotificationList", ref MapNotificationList);
+        dataStore.SyncData("NestedData", ref NestedData);
     }
 
-    public class CustomMapNotification : InformationData
-    {
-        // InformationData already contains 5 definitions, so start from 6 for custom data
-        [SaveableProperty(6)]
-        public Hero Mercenary { get; set; }
+    public override void RegisterEvents() { }
+}
 
-        [SaveableProperty(7)]
-        public bool IsHandled { get; set; }
-    }
-    
-    public struct NestedStruct
+public class CustomSaveDefiner : SaveableTypeDefiner
+{
+    // use a big number and ensure that no other mod is using a close range
+    public CustomSaveDefiner() : base(2_333_000) { }
+
+    protected override void DefineClassTypes()
     {
-        [SaveableField(1)]
-        public bool Flag;
+        // The Id's here are local and will be related to the Id passed to the constructor
+        AddClassDefinition(typeof(CustomMapNotification), 1);
+        AddStructDefinition(typeof(ExampleStruct), 2);
+        AddClassDefinition(typeof(ExampleNested), 3);
+        AddStructDefinition(typeof(NestedStruct), 4);
     }
-    public class ExampleNested
+
+    protected override void DefineContainerDefinitions()
     {
-        [SaveableField(1)]
-        public NestedStruct Data;
+        ConstructContainerDefinition(typeof(List<CustomMapNotification>));
+        // Both of these are necessary: order isn't important
+        ConstructContainerDefinition(typeof(List<NestedStruct>));
+        ConstructContainerDefinition(typeof(Dictionary<string, List<NestedStruct>>));
     }
+}
+
+public struct ExampleStruct
+{
+    // Local ID's start from one if the class/struct does not inherit from any
+    // game's types with saveable data
+    [SaveableField(1)]
+    public PartyBase Attacker;
+}
+
+public class CustomMapNotification : InformationData
+{
+    // InformationData already contains 5 definitions, so start from 6 for custom data
+    [SaveableProperty(6)]
+    public Hero Mercenary { get; set; }
+
+    [SaveableProperty(7)]
+    public bool IsHandled { get; set; }
+}
+
+public struct NestedStruct
+{
+    [SaveableField(1)]
+    public bool Flag;
+}
+public class ExampleNested
+{
+    [SaveableField(1)]
+    public NestedStruct Data;
+}
 ```
-  
-## CampaignBehaviorBase.SyncData
-There is also "shared data" that could be used between one/miltiple ``CampaignBehaviorBase``.  
-With it you can store custom container data, such as:  
-* Array
-* List
-* Dictionary
-* Queue
-```csharp
-    public class CustomBehavior : CampaignBehaviorBase
-    {
-        private List<ExampleStruct> _customDataMap = new List<ExampleStruct>();
 
-        public override void SyncData(IDataStore dataStore)
-        {
-            dataStore.SyncData("customDataMap", ref _customDataMap);
-        }
-        
-        public override void RegisterEvents() { }
-    }
-```
-  
-## Alternative approach
-Instead of relying on the `SaveableTypeDefiner` that will lock the save file, the community found out another method of saving data without the issue, by using JSON serialization.  
+### Notes:
+The community should decide how to handle ``saveBaseId`` collisions.
+
+## Alternative approach - JSON serialization
+Instead of relying on the `SaveableTypeDefiner` that will lock the save file, the community found out another method of saving data without the issue, by using JSON serialization.
 ```csharp
     public class CustomJSONBehavior : CampaignBehaviorBase
     {
@@ -179,7 +222,3 @@ The game also has a hard limit on the string size. We don't know the exact maxim
             }
         }
 ```
-  
-  
-### Notes:
-The community should decide how to handle ``saveBaseId`` collisions.  

--- a/docs/_csharp-api/savesystem/README.md
+++ b/docs/_csharp-api/savesystem/README.md
@@ -6,7 +6,7 @@ If the data will be saved to the game's internal storage, upon removing your mod
 This will be the case when definining custom ``LogEntry`` types and passing them to the game (``LogEntry.AddLogEntry(customLog);``).  
 As a workaround, you should either include a feature to fully remove your custom data from the game or provide a mod for it.
 
-## Basic saving
+## Basic saving - SyncData
 
 The core of saving is ``CampaignBehaviorBase``'s ``SyncData`` function.  This will be called on any registered campaign behavior on both saving and loading.
 
@@ -27,6 +27,29 @@ public class CustomBehavior : CampaignBehaviorBase
     public override void RegisterEvents() { }
 }
 ```
+
+### Advanced pattern - serialization/deserialization in `SyncData`
+
+While it's most common to provide a ref to a class property, a ref can also be provided to a local variable, which can be used to specially serialize and deserialize data, alongside the ``IsLoading`` and ``IsSaving`` properties of the ``IDataStore``.
+
+```csharp
+public override void SyncData(IDataStore dataStore)
+{
+    var dataToSave = new List<string>();
+    if(dataStore.IsSaving) {
+        // Load the data to save into the list, can gather data from other parts of the mod
+        dataToSave = gatherData();
+    }
+    dataStore.SyncData("dataToSave", ref dataToSave);
+    if(dataStore.IsLoading) {
+        // The save data has been loaded into dataToSave array.
+        // Do whatever logic is necessary to restore the state based on the saved data
+        restoreData(dataToSave);
+    }
+}
+```
+
+A more complete example of this is shown below in the JSON serialization section
 
 ## SaveableTypeDefiner
 


### PR DESCRIPTION
There's been some discussion in the discord about the section on saving not being as helpful as it could be.  I've made an attempt to restructure the existing content and adding small bits of new content to hopefully clarify the page.

* Prioritize explanation of SyncData - it's the core of saving, but doesn't show up until near the bottom of the explanation.  
  * Link to MDN docs on `ref` since it's a somewhat rare C# construct, AFAIK.
* Split explanation of SaveableTypeDefiner by purpose - saving classes vs. saving data structures
* Flesh out explanation of saving data structures - the previous version mentioned saving data structures in the `SyncData` section and had an example of `DefineContainerDefinitions` but no direct explanation.  
  * Included an example for the nested (e.g `List<List<SomeType>>`) case, as that was what tripped me up with the save system.
* Ensured that the `SaveableTypeDefiner` example included `SyncData`, since some people seem to think the `SavableTypeDefiner` is an alternative to `SyncData`.
* Added a specific section on the `IsSaving`/`IsLoading` pattern for `SyncData` (might be slightly redundant with the JSON section)