### PR TITLE
Typo fix in hero.md

### DIFF
--- a/docs/_csharp-api/campaignsystem/hero.md
+++ b/docs/_csharp-api/campaignsystem/hero.md
@@ -54,7 +54,7 @@ TODO
  | IsMercenary       | IsMercenary                   | `bool`                                                         | Is hero mercenary                          |       |
  | SpcDaysInLocation | SpcDaysInLocation             | `int`                                                          | TODO                                       |       |
  | private           | _health                       | `int`                                                          | Health                                     |       |
- | private           | _birthDay                     | [CampaignTime]()                                               | BearthDay                                  |       |
+ | private           | _birthDay                     | [CampaignTime]()                                               | BirthDay                                   |       |
  | private           | _deathDay                     | [CampaignTime]()                                               | Day of death                               |       |
  | private           | _power                        | `int`                                                          | Power                                      |       |
  | public            | VisitedSettlements            | `Dictionary<`[Settlement]()`, float>`                          | Visited settlements                        |       |


### PR DESCRIPTION
Fixes the "Bearth" typo in the C# API here:
<img width="1916" height="923" alt="bearth day" src="https://github.com/user-attachments/assets/3d17494c-e624-40ec-82b7-76e3b2a05684" />
This fixes the issue I opened: #142
